### PR TITLE
Unit Color Replacement via Config

### DIFF
--- a/resources/config/defaults.toml
+++ b/resources/config/defaults.toml
@@ -19,3 +19,8 @@ location = [ 0, 0 ] # [x, y] in pixels
 theatre = "KTO" # Theatre to load the map for on startup
 map_alpha = 100 # 0-255 # Alpha value for the map, the lower the value the more transparent the map will be
 background_color = [ 50, 50, 50 ] # [r, g, b] # Background color for the map
+# Colors that want to be switched from the Tacview default to a custom value, for better visibility.
+# Accepts the format [defaultcolor, newcolor], where the first arguments is a color String, and the second a color String or [r, g, b] array
+unit_color_switching = [
+    ["Blue", [0, 225, 255]]
+]

--- a/src/game_objects.py
+++ b/src/game_objects.py
@@ -36,7 +36,6 @@ class GameObject:
 
         # Switch the object's color from its default to a respective replacement color
         for i in config.app_config.get("map", "unit_color_switching", list):
-            print(self.color, "==", i[0])
             if self.color == pygame.Color(i[0]):
                 if isinstance(i[1], list):
                     self.color = pygame.Color(i[1])

--- a/src/game_objects.py
+++ b/src/game_objects.py
@@ -2,6 +2,9 @@ import pygame
 
 import numpy as np
 
+import tomlkit
+import config
+
 from bms_math import *
 from typing import Callable, Any
 from acmi_parse import ACMIObject
@@ -30,7 +33,16 @@ class GameObject:
             font = pygame.font.SysFont("couriernewbold", 22)
         self.font = font
         
-        self.color = pygame.Color(self.data.Color) 
+        self.color = pygame.Color(self.data.Color)
+
+        # Switch the object's color from its default to a respective replacement color
+        for i in config.app_config.get("map", "unit_color_switching", list):
+            print(self.color, "==", i[0])
+            if self.color == pygame.Color(i[0]):
+                if type(i[1]) != tomlkit.items.Array:
+                    self.color = pygame.Color(i[1])
+                else:
+                    self.color = pygame.Color(i[1][0], i[1][1], i[1][2])
         
     def get_display_name(self) -> str:
 

--- a/src/game_objects.py
+++ b/src/game_objects.py
@@ -2,7 +2,6 @@ import pygame
 
 import numpy as np
 
-import tomlkit
 import config
 
 from bms_math import *
@@ -39,7 +38,7 @@ class GameObject:
         for i in config.app_config.get("map", "unit_color_switching", list):
             print(self.color, "==", i[0])
             if self.color == pygame.Color(i[0]):
-                if type(i[1]) != tomlkit.items.Array:
+                if isinstance(i[1], list):
                     self.color = pygame.Color(i[1])
                 else:
                     self.color = pygame.Color(i[1][0], i[1][1], i[1][2])


### PR DESCRIPTION
I developed a rudimentary way to switch specific unit colours with others, by defining them in the config.

My main goal was simply to make BLUFOR units more visible, as I found the standard "Blue" (#0000FF) colour imported from Tacview to be too dark and hard to read at a glance.

But maybe in the future this could be developed further into some colour-blindness options 🤷🏻‍♂️