### PR TITLE
Fixes #28 - fix config when running from exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ test.py
 output.txt
 imgui.ini
 renderdoc.cap
+openradar.toml
+openradar_imgui.ini

--- a/src/app.py
+++ b/src/app.py
@@ -290,6 +290,8 @@ class App:
         """
         Cleans up and quits the application.
         """
+        print("Cleaning up and saving configuration...")
+        config.app_config.save()
         if self.gpu_timer:
             self.gpu_timer.cleanup()
         glfw.terminate()

--- a/src/ui/imgui_ui.py
+++ b/src/ui/imgui_ui.py
@@ -46,6 +46,8 @@ example_object.AOA = 5.0
 example_object.Coalition = "U.S."
 example_object.Name = "F-16C"
 
+IMGUI_INI_FILENAME = "openradar_imgui.ini"
+
 
 def help_marker(description: str):
     imgui.text_disabled("(?)")
@@ -128,6 +130,10 @@ class ImguiUserInterface:
         imgui.create_context()
         io = imgui.get_io()
         io.display_size = self.size
+
+        print(f"Imgui INI file path: {str(config.application_dir / IMGUI_INI_FILENAME)}")
+        io.set_ini_filename(str(config.application_dir / IMGUI_INI_FILENAME))
+
         io.fonts.add_font_from_file_ttf(str(config.bundle_dir / "resources/fonts/ProggyClean.ttf"), 18)
 
         # Enable docking support


### PR DESCRIPTION
Fixes #28 
The config file wasn't writing to the proper path when the program saved the config from the exe, as the cwd was changing to the virtual folder. 
This makes both imgui and the config files write to absolute paths derived from where the .exe or .py file is being run