### PR TITLE
Abbrev2 and abbrev3

### DIFF
--- a/src/game_object.py
+++ b/src/game_object.py
@@ -40,8 +40,8 @@ from util.bms_math import M_PER_SEC_TO_KNOTS, METERS_TO_FT
 from util.other_utils import rgba_from_str
 
 #
-# Abbrev Name is intended to shorten Callsign like Trojan 21
-# to TN21
+# Abbrev Name is intended to shorten Callsign like Satan21 to SN21
+# Requires Python REGEXP Module: re
 # ~BS1 8/30/25
 #
 import re


### PR DESCRIPTION
All changes in game_object.py

Adds code to change Pilot Name for example Satan21 to SN21 or SAN21.
2 Letter abbrev gives several possible collisions.
3 Letter abbrev gives only 1 collision that is unlikely to be seen in the game.

Baseline code is ready to be implemented on to Self.CallSign, when the ACMI file output by BMS is updated.

Requires Python REGEX module re